### PR TITLE
Multidimensional metrics

### DIFF
--- a/src/collectors/statsd.rs
+++ b/src/collectors/statsd.rs
@@ -151,7 +151,7 @@ fn handle_line(store: &SharedStore, line: String) {
 mod tests {
     use super::handle_line;
     use super::super::super::SharedStore;
-    use super::super::super::metrics::{AggregatedMetrics, AggregatedMetricType};
+    use super::super::super::metrics::{AggregatedMetrics, AggregatedMetricType, Dimension};
 
     #[test]
     fn handle_line_parses_metrics() {
@@ -159,7 +159,7 @@ mod tests {
         handle_line(&store, "foo:1|g".to_owned());
 
         assert_eq!(store.flush(), AggregatedMetrics::with_metrics(vec![
-            (AggregatedMetricType::Sample, "foo".to_owned(), 1.0),
+            (AggregatedMetricType::Sample, Dimension::with_name("foo"), 1.0),
         ]));
     }
 }

--- a/src/forwarders/datadog.rs
+++ b/src/forwarders/datadog.rs
@@ -98,6 +98,7 @@ mod tests {
     use super::super::super::metrics::{
         AggregatedMetrics,
         AggregatedMetricType,
+        Dimension,
     };
 
     use rustc_serialize::json::ToJson;
@@ -105,7 +106,7 @@ mod tests {
     #[test]
     fn datadog_forwarder_serializes_metrics() {
         let metrics = AggregatedMetrics::with_metrics(vec![
-            (AggregatedMetricType::Count, "test_count".to_owned(), 1.0),
+            (AggregatedMetricType::Count, Dimension::with_name("test_count"), 1.0),
         ]);
         let json = DatadogForwarder::serialize_metrics(metrics);
 

--- a/src/forwarders/datadog.rs
+++ b/src/forwarders/datadog.rs
@@ -37,7 +37,7 @@ impl DatadogForwarder {
             .map(|metric| {
                 let mut object: BTreeMap<String, Json> = BTreeMap::new();
 
-                let (ref metric_type, ref name, ref value) = *metric;
+                let (ref metric_type, ref dim, ref value) = *metric;
 
                 let api_type = match *metric_type {
                     Count   => "count",
@@ -45,7 +45,7 @@ impl DatadogForwarder {
                     Sample  => "gauge",
                 };
 
-                object.insert("metric".to_owned(), name.to_json());
+                object.insert("metric".to_owned(), dim.name.to_json());
                 object.insert("type".to_owned(), api_type.to_json());
                 object.insert("points".to_owned(), Json::Array(vec![
                     Json::Array(vec![ timestamp.to_json(), value.to_json() ]),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -18,12 +18,21 @@ pub enum Metric {
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Dimension {
     pub name: String,
+    pub source: Option<String>,
 }
 
 impl Dimension {
     pub fn with_name<S: AsRef<str>>(name: S) -> Dimension {
         Dimension {
             name: name.as_ref().to_owned(),
+            source: None,
+        }
+    }
+
+    pub fn with_name_and_source<S: AsRef<str>>(name: S, source: S) -> Dimension {
+        Dimension {
+            name: name.as_ref().to_owned(),
+            source: Some(source.as_ref().to_owned()),
         }
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -8,14 +8,14 @@ pub use self::Metric::*;
 /// Metric collected from a collector to be recorded in a store.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Metric {
-    Count(String, u64),
-    Measure(String, f64),
-    Sample(String, f64),
+    Count(Dimension, u64),
+    Measure(Dimension, f64),
+    Sample(Dimension, f64),
 }
 
 /// Metrics can grouped by multiple values. Right now that limited to just
 /// their name.
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct Dimension {
     pub name: String,
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -59,10 +59,10 @@ impl AggregatedMetrics {
     }
 
     pub fn aggregate_counts<'a, I>(&mut self, counts: I)
-        where I: Iterator<Item=(&'a str, &'a u64)>
+        where I: Iterator<Item=(&'a Dimension, &'a u64)>
     {
-        for (name, value) in counts {
-            self.metrics.push((AggregatedMetricType::Count, name.to_owned(), *value as f64))
+        for (dim, value) in counts {
+            self.metrics.push((AggregatedMetricType::Count, dim.name.to_owned(), *value as f64))
         }
     }
 
@@ -71,11 +71,11 @@ impl AggregatedMetrics {
     /// emitted, as well as a total count of all the individual measures
     /// received in the period.
     pub fn aggregate_measures<'a, I>(&mut self, measures: I)
-        where I: Iterator<Item=(&'a str, &'a Vec<f64>)>
+        where I: Iterator<Item=(&'a Dimension, &'a Vec<f64>)>
     {
         use self::AggregatedMetricType::*;
 
-        for (name, values) in measures {
+        for (dim, values) in measures {
             let mut sorted = values.clone();
             sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Equal));
 
@@ -86,22 +86,22 @@ impl AggregatedMetrics {
             let percentile95 = sorted[(sorted.len() as f64 * 0.95) as usize];
             let percentile99 = sorted[(sorted.len() as f64 * 0.99) as usize];
 
-            self.metrics.push((Measure, format!("{}.min",          name), min));
-            self.metrics.push((Measure, format!("{}.max",          name), max));
-            self.metrics.push((Measure, format!("{}.median",       name), median));
-            self.metrics.push((Measure, format!("{}.avg",          name), average));
-            self.metrics.push((Measure, format!("{}.95percentile", name), percentile95));
-            self.metrics.push((Measure, format!("{}.99percentile", name), percentile99));
+            self.metrics.push((Measure, format!("{}.min",          dim.name), min));
+            self.metrics.push((Measure, format!("{}.max",          dim.name), max));
+            self.metrics.push((Measure, format!("{}.median",       dim.name), median));
+            self.metrics.push((Measure, format!("{}.avg",          dim.name), average));
+            self.metrics.push((Measure, format!("{}.95percentile", dim.name), percentile95));
+            self.metrics.push((Measure, format!("{}.99percentile", dim.name), percentile99));
 
-            self.metrics.push((Count,   format!("{}.count", name), sorted.len() as f64));
+            self.metrics.push((Count,   format!("{}.count", dim.name), sorted.len() as f64));
         }
     }
 
     pub fn aggregate_samples<'a, I>(&mut self, samples: I)
-        where I: Iterator<Item=(&'a str, &'a f64)>
+        where I: Iterator<Item=(&'a Dimension, &'a f64)>
     {
-        for (name, value) in samples {
-            self.metrics.push((AggregatedMetricType::Sample, name.to_owned(), *value as f64))
+        for (dim, value) in samples {
+            self.metrics.push((AggregatedMetricType::Sample, dim.name.to_owned(), *value as f64))
         }
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,3 @@
-use std::collections::hash_map;
 use std::slice::Iter;
 use std::cmp::Ordering::Equal;
 
@@ -44,7 +43,9 @@ impl AggregatedMetrics {
         }
     }
 
-    pub fn aggregate_counts(&mut self, counts: hash_map::Iter<String, u64>) {
+    pub fn aggregate_counts<'a, I>(&mut self, counts: I)
+        where I: Iterator<Item=(&'a str, &'a u64)>
+    {
         for (name, value) in counts {
             self.metrics.push((AggregatedMetricType::Count, name.to_owned(), *value as f64))
         }
@@ -54,7 +55,9 @@ impl AggregatedMetrics {
     /// average (mean), and 95th percentile summary measures will all be
     /// emitted, as well as a total count of all the individual measures
     /// received in the period.
-    pub fn aggregate_measures(&mut self, measures: hash_map::Iter<String, Vec<f64>>) {
+    pub fn aggregate_measures<'a, I>(&mut self, measures: I)
+        where I: Iterator<Item=(&'a str, &'a Vec<f64>)>
+    {
         use self::AggregatedMetricType::*;
 
         for (name, values) in measures {
@@ -79,7 +82,9 @@ impl AggregatedMetrics {
         }
     }
 
-    pub fn aggregate_samples(&mut self, samples: hash_map::Iter<String, f64>) {
+    pub fn aggregate_samples<'a, I>(&mut self, samples: I)
+        where I: Iterator<Item=(&'a str, &'a f64)>
+    {
         for (name, value) in samples {
             self.metrics.push((AggregatedMetricType::Sample, name.to_owned(), *value as f64))
         }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -29,7 +29,7 @@ impl Dimension {
         }
     }
 
-    pub fn with_name_and_source<S: AsRef<str>>(name: S, source: S) -> Dimension {
+    pub fn with_name_and_source<N: AsRef<str>, S: AsRef<str>>(name: N, source: S) -> Dimension {
         Dimension {
             name: name.as_ref().to_owned(),
             source: Some(source.as_ref().to_owned()),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -13,6 +13,21 @@ pub enum Metric {
     Sample(String, f64),
 }
 
+/// Metrics can grouped by multiple values. Right now that limited to just
+/// their name.
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub struct Dimension {
+    pub name: String,
+}
+
+impl Dimension {
+    pub fn with_name<S: AsRef<str>>(name: S) -> Dimension {
+        Dimension {
+            name: name.as_ref().to_owned(),
+        }
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum AggregatedMetricType {
     Count,

--- a/src/parsers/statsd.rs
+++ b/src/parsers/statsd.rs
@@ -10,7 +10,7 @@ use nom::{
     IResult
 };
 
-use super::super::metrics::Metric;
+use super::super::metrics::{Dimension, Metric};
 
 /// Parsed StatsD metric.
 ///
@@ -27,9 +27,9 @@ impl ParsedMetric {
         use self::ParsedMetric::*;
 
         match self {
-            &Counter(ref name, value) => Metric::Count(name.clone(), value),
-            &Gauge(ref name, value)   => Metric::Sample(name.clone(), value as f64),
-            &Timer(ref name, value)   => Metric::Measure(name.clone(), value as f64),
+            &Counter(ref name, value) => Metric::Count(Dimension::with_name(name), value),
+            &Gauge(ref name, value)   => Metric::Sample(Dimension::with_name(name), value as f64),
+            &Timer(ref name, value)   => Metric::Measure(Dimension::with_name(name), value as f64),
         }
     }
 }

--- a/src/store.rs
+++ b/src/store.rs
@@ -45,13 +45,13 @@ impl BaseStore {
     pub fn flush(&mut self) -> AggregatedMetrics {
         let mut aggregated = AggregatedMetrics::new();
 
-        aggregated.aggregate_counts(self.counts.iter().map(|(d, v)| (d.name.as_str(), v)));
+        aggregated.aggregate_counts(self.counts.iter());
         self.counts.clear();
 
-        aggregated.aggregate_measures(self.measures.iter().map(|(d, v)| (d.name.as_str(), v)));
+        aggregated.aggregate_measures(self.measures.iter());
         self.measures.clear();
 
-        aggregated.aggregate_samples(self.samples.iter().map(|(d, v)| (d.name.as_str(), v)));
+        aggregated.aggregate_samples(self.samples.iter());
         self.samples.clear();
 
         aggregated

--- a/src/store.rs
+++ b/src/store.rs
@@ -5,21 +5,6 @@ use std::time::Duration;
 
 use metrics::*;
 
-/// Metrics can grouped by multiple values. Right now that limited to just
-/// their name.
-#[derive(Debug, Eq, PartialEq, Hash)]
-struct Dimension {
-    name: String,
-}
-
-impl Dimension {
-    pub fn with_name<S: AsRef<str>>(name: S) -> Dimension {
-        Dimension {
-            name: name.as_ref().to_owned(),
-        }
-    }
-}
-
 /// Internal storage of metrics data. Normally you will want a `SharedStore`
 /// which wraps this in an `Arc<Mutex<BaseStore>>` for thread-safe sharing
 /// and access.
@@ -140,7 +125,7 @@ impl SharedStore {
 mod tests {
     use std::collections::HashMap;
 
-    use super::{BaseStore, Dimension};
+    use super::BaseStore;
     use super::super::metrics::*;
 
     fn get_store_with_metrics() -> BaseStore {

--- a/src/store.rs
+++ b/src/store.rs
@@ -26,16 +26,16 @@ impl BaseStore {
     pub fn record(&mut self, metrics: Vec<Metric>) {
         for metric in metrics {
             match metric {
-                Count(name, value) => {
-                    let count = self.counts.entry(Dimension::with_name(name)).or_insert(0);
+                Count(dim, value) => {
+                    let count = self.counts.entry(dim).or_insert(0);
                     *count += value;
                 },
-                Measure(name, value) => {
-                    let values = self.measures.entry(Dimension::with_name(name)).or_insert(Vec::new());
+                Measure(dim, value) => {
+                    let values = self.measures.entry(dim).or_insert(Vec::new());
                     values.push(value);
                 },
-                Sample(name, value) => {
-                    let entry = self.samples.entry(Dimension::with_name(name)).or_insert(0.0);
+                Sample(dim, value) => {
+                    let entry = self.samples.entry(dim).or_insert(0.0);
                     *entry = value;
                 }
             }
@@ -130,12 +130,12 @@ mod tests {
 
     fn get_store_with_metrics() -> BaseStore {
         let metrics = vec![
-            Count("foo".to_owned(), 1),
-            Count("foo".to_owned(), 2),
-            Measure("bar".to_owned(), 3.4),
-            Measure("bar".to_owned(), 5.6),
-            Sample("baz".to_owned(), 7.8),
-            Sample("baz".to_owned(), 9.0),
+            Count(Dimension::with_name("foo"), 1),
+            Count(Dimension::with_name("foo"), 2),
+            Measure(Dimension::with_name("bar"), 3.4),
+            Measure(Dimension::with_name("bar"), 5.6),
+            Sample(Dimension::with_name("baz"), 7.8),
+            Sample(Dimension::with_name("baz"), 9.0),
         ];
 
         let mut store = BaseStore::new();


### PR DESCRIPTION
- Changes the concept of a metric: originally it was a name and values/aggregated value, now it is a dimension—a name plus an optional source—and values/aggregated value.
- Parses source expressions ("source=...") in log lines.
- Passes the source—if present—to Datadog as a tag.
