### PR TITLE
Update dependencies to support OpenSSL versions >= 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "metrics_distributor"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Dirk Gadsden <dirk@esherido.com>"]
 description = "Ingest logs and forward aggregated data to APIs/services."
 license = "BSD-3-Clause"
 repository = "https://github.com/dirk/metrics_distributor"
 
 [dependencies]
-hyper = "0.10.13"
-iron = "0.5.1"
-router = "0.5.1"
-reqwest = "0.6.2"
+hyper = "0.13.4"
+iron = "0.6.1"
+router = "0.6.0"
+reqwest = { version = "0.10.4", features = ["blocking"] }
 regex = "0.2.1"
 lazy_static = "0.1.16"
 nom = "2.2.1"

--- a/src/forwarders/datadog.rs
+++ b/src/forwarders/datadog.rs
@@ -1,8 +1,8 @@
 //! Reports metrics to Datadog through their HTTPS API.
 
 use chrono::UTC;
-use hyper::header::ContentType;
-use reqwest::{Client, RequestBuilder};
+use hyper::header::CONTENT_TYPE;
+use reqwest::blocking::{Client, RequestBuilder};
 use rustc_serialize::json::{self, Json, ToJson};
 use std::collections::BTreeMap;
 
@@ -72,14 +72,14 @@ impl DatadogForwarder {
         let path = format!("{}{}?api_key={}", self.base_url, path, self.api_key);
 
         client.post(&path)
-            .header(ContentType::json())
+            .header(CONTENT_TYPE, "application/json")
     }
 }
 
 impl Forwarder for DatadogForwarder {
     fn forward_metrics(&self, metrics: AggregatedMetrics) {
         let body = json::encode(&DatadogForwarder::serialize_metrics(metrics)).unwrap();
-        let client = Client::new().unwrap();
+        let client = Client::new();
 
         let res = self.post(&client, "/v1/series")
             .body(body)


### PR DESCRIPTION
Makes the required updates to bring in an updated version of Rust's `openssl` crate, per sfackler/rust-openssl#987. Compiled and tested against Rust 1.42.0
Some of the updated dependencies introduced breaking changes, which have been addressed as well.